### PR TITLE
Add md5sum-typescript: from-scratch md5sum CLI (Coding Challenge #120)

### DIFF
--- a/md5sum-typescript/README.md
+++ b/md5sum-typescript/README.md
@@ -1,0 +1,111 @@
+# md5sum-typescript
+
+A TypeScript implementation of the Unix `md5sum` utility, written for [Coding
+Challenges #120](https://codingchallenges.substack.com/p/coding-challenge-120-md5sum).
+
+The MD5 algorithm itself is implemented from scratch following
+[RFC 1321](https://www.rfc-editor.org/rfc/rfc1321) — no `node:crypto`, no
+third-party hash library.
+
+## Layout
+
+```
+src/
+  md5.ts        # streaming MD5 implementation
+  md5sum.ts     # argv parsing, file I/O, check mode
+  cli.ts        # thin entry point
+test/
+  md5.test.ts
+  md5sum.test.ts
+```
+
+## Install & build
+
+```sh
+npm install
+npm run build
+```
+
+Or run directly with `ts-node`:
+
+```sh
+npm start -- README.md
+# or
+npx ts-node src/cli.ts README.md
+```
+
+## Usage
+
+```
+md5sum-ts [OPTION]... [FILE]...
+
+  -b, --binary      read in binary mode (prefixes filename with '*')
+  -c, --check       verify checksums listed in FILE
+  -t, --text        read in text mode (default)
+      --quiet       don't print OK lines while checking
+      --status      don't print anything; rely on exit code
+      --strict      exit non-zero on malformed checksum lines
+  -w, --warn        warn about malformed checksum lines
+      --help        show this help
+```
+
+With no FILE, or when FILE is `-`, it reads from standard input.
+
+## Walkthrough of the challenge steps
+
+### Step 1 — hash one or more files
+
+```sh
+$ md5sum-ts README.md src/md5.ts
+e2c2...c3  README.md
+4b9a...11  src/md5.ts
+```
+
+Output is `<32-hex>  <filename>` (two spaces), matching GNU `md5sum`. A missing
+file produces an error on stderr and a non-zero exit code; other files still
+get hashed.
+
+### Step 2 — binary mode
+
+```sh
+$ md5sum-ts -b /bin/ls
+93f2...0d *bin/ls
+```
+
+The space before the filename becomes `*`, exactly as the system `md5sum`
+prints it. Compare against your OS's `md5sum -b /bin/ls` to verify.
+
+### Steps 3 & 4 — check mode
+
+```sh
+$ md5sum-ts README.md src/md5.ts > sums.md5
+$ md5sum-ts -c sums.md5
+README.md: OK
+src/md5.ts: OK
+```
+
+If any computed checksum disagrees with the file, that line prints `FAILED`
+and the process exits non-zero. Missing files are reported as
+`FAILED open or read`. The verifier accepts both text-mode (`  `) and
+binary-mode (` *`) lines and ignores trailing `\r` so CRLF checksum files
+work.
+
+`--quiet`, `--status`, `--warn`, and `--strict` behave the same as in GNU
+`md5sum`.
+
+## Tests
+
+```sh
+npm test
+```
+
+Covers:
+
+- The RFC 1321 test vectors.
+- The 55/56/64-byte padding boundary cases (where the algorithm has to add an
+  extra block).
+- Streaming the same input one character at a time vs. as a single buffer.
+- A 1 MiB input verified against `crypto.createHash('md5')`.
+- Argv parsing, including `--`, grouped short flags, and `-` as a filename.
+- End-to-end: hashing real files, binary mode, missing files, check mode (OK,
+  FAILED, missing, malformed, `--quiet`, `--status`).

--- a/md5sum-typescript/package-lock.json
+++ b/md5sum-typescript/package-lock.json
@@ -1,0 +1,239 @@
+{
+  "name": "@scottobert/md5sum-typescript",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scottobert/md5sum-typescript",
+      "version": "1.0.0",
+      "license": "GPL-2.0",
+      "bin": {
+        "md5sum-ts": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/md5sum-typescript/package.json
+++ b/md5sum-typescript/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@scottobert/md5sum-typescript",
+  "version": "1.0.0",
+  "private": true,
+  "description": "md5sum implemented from scratch in TypeScript (Coding Challenge #120).",
+  "license": "GPL-2.0",
+  "bin": {
+    "md5sum-ts": "dist/cli.js"
+  },
+  "main": "dist/md5sum.js",
+  "types": "dist/md5sum.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/cli.ts",
+    "test": "node --require ts-node/register --test test/md5.test.ts test/md5sum.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.2"
+  }
+}

--- a/md5sum-typescript/src/cli.ts
+++ b/md5sum-typescript/src/cli.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { run } from "./md5sum";
+
+async function main(): Promise<void> {
+  const result = await run(process.argv.slice(2));
+  for (const l of result.stdout) process.stdout.write(l + "\n");
+  for (const l of result.stderr) process.stderr.write(l + "\n");
+  process.exit(result.exitCode);
+}
+
+void main();

--- a/md5sum-typescript/src/md5.ts
+++ b/md5sum-typescript/src/md5.ts
@@ -1,0 +1,141 @@
+// MD5 (RFC 1321) implemented from scratch.
+// Operates on 32-bit unsigned words and produces a 128-bit digest.
+
+const S: readonly number[] = [
+  7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+  5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+  4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+  6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+const K: readonly number[] = (() => {
+  const out: number[] = [];
+  for (let i = 0; i < 64; i++) {
+    out.push(Math.floor(Math.abs(Math.sin(i + 1)) * 0x1_0000_0000) >>> 0);
+  }
+  return out;
+})();
+
+function rotl(x: number, n: number): number {
+  return ((x << n) | (x >>> (32 - n))) >>> 0;
+}
+
+function add32(...xs: number[]): number {
+  let s = 0;
+  for (const x of xs) s = (s + x) >>> 0;
+  return s;
+}
+
+export class Md5 {
+  private a = 0x67452301;
+  private b = 0xefcdab89;
+  private c = 0x98badcfe;
+  private d = 0x10325476;
+  private totalLen = 0; // total bytes hashed
+  private buffer = Buffer.alloc(64);
+  private bufferLen = 0;
+
+  update(chunk: Buffer | Uint8Array | string): this {
+    const data = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : Buffer.from(chunk);
+    this.totalLen += data.length;
+    let offset = 0;
+
+    if (this.bufferLen > 0) {
+      const need = 64 - this.bufferLen;
+      const take = Math.min(need, data.length);
+      data.copy(this.buffer, this.bufferLen, 0, take);
+      this.bufferLen += take;
+      offset += take;
+      if (this.bufferLen === 64) {
+        this.processBlock(this.buffer, 0);
+        this.bufferLen = 0;
+      }
+    }
+
+    while (data.length - offset >= 64) {
+      this.processBlock(data, offset);
+      offset += 64;
+    }
+
+    if (offset < data.length) {
+      data.copy(this.buffer, 0, offset);
+      this.bufferLen = data.length - offset;
+    }
+
+    return this;
+  }
+
+  digest(): Buffer {
+    // Padding: append 0x80, then zeros, then 64-bit little-endian length-in-bits.
+    const tail = Buffer.alloc(this.bufferLen < 56 ? 64 : 128);
+    this.buffer.copy(tail, 0, 0, this.bufferLen);
+    tail[this.bufferLen] = 0x80;
+
+    // Bit length, little-endian, 64 bits. JS bit ops are 32-bit, so split.
+    const bits = this.totalLen * 8;
+    const low = bits >>> 0;
+    const high = Math.floor(bits / 0x1_0000_0000) >>> 0;
+    tail.writeUInt32LE(low, tail.length - 8);
+    tail.writeUInt32LE(high, tail.length - 4);
+
+    for (let off = 0; off < tail.length; off += 64) {
+      this.processBlock(tail, off);
+    }
+
+    const out = Buffer.alloc(16);
+    out.writeUInt32LE(this.a, 0);
+    out.writeUInt32LE(this.b, 4);
+    out.writeUInt32LE(this.c, 8);
+    out.writeUInt32LE(this.d, 12);
+    return out;
+  }
+
+  hex(): string {
+    return this.digest().toString("hex");
+  }
+
+  private processBlock(block: Buffer, offset: number): void {
+    const M = new Array<number>(16);
+    for (let i = 0; i < 16; i++) {
+      M[i] = block.readUInt32LE(offset + i * 4);
+    }
+
+    let a = this.a;
+    let b = this.b;
+    let c = this.c;
+    let d = this.d;
+
+    for (let i = 0; i < 64; i++) {
+      let f: number;
+      let g: number;
+      if (i < 16) {
+        f = (b & c) | (~b & d);
+        g = i;
+      } else if (i < 32) {
+        f = (d & b) | (~d & c);
+        g = (5 * i + 1) % 16;
+      } else if (i < 48) {
+        f = b ^ c ^ d;
+        g = (3 * i + 5) % 16;
+      } else {
+        f = c ^ (b | ~d);
+        g = (7 * i) % 16;
+      }
+      f = f >>> 0;
+      const temp = d;
+      d = c;
+      c = b;
+      b = add32(b, rotl(add32(a, f, K[i], M[g]), S[i]));
+      a = temp;
+    }
+
+    this.a = add32(this.a, a);
+    this.b = add32(this.b, b);
+    this.c = add32(this.c, c);
+    this.d = add32(this.d, d);
+  }
+}
+
+export function md5Hex(data: Buffer | Uint8Array | string): string {
+  return new Md5().update(data).hex();
+}

--- a/md5sum-typescript/src/md5sum.ts
+++ b/md5sum-typescript/src/md5sum.ts
@@ -1,0 +1,292 @@
+import { createReadStream } from "node:fs";
+import { open } from "node:fs/promises";
+import { Md5 } from "./md5";
+
+export interface Options {
+  binary: boolean;
+  check: boolean;
+  quiet: boolean;
+  status: boolean;
+  strict: boolean;
+  warn: boolean;
+  files: string[];
+}
+
+export interface ParseResult {
+  options: Options;
+  help: boolean;
+  error?: string;
+}
+
+const HELP = `Usage: md5sum [OPTION]... [FILE]...
+Print or check MD5 (128-bit) checksums.
+
+With no FILE, or when FILE is -, read standard input.
+
+  -b, --binary         read in binary mode
+  -c, --check          read checksums from the FILEs and check them
+  -t, --text           read in text mode (default)
+      --quiet          don't print OK for each successfully verified file
+      --status         don't output anything, status code shows success
+      --strict         exit non-zero for improperly formatted checksum lines
+  -w, --warn           warn about improperly formatted checksum lines
+      --help           display this help and exit
+`;
+
+export function parseArgs(argv: readonly string[]): ParseResult {
+  const opts: Options = {
+    binary: false,
+    check: false,
+    quiet: false,
+    status: false,
+    strict: false,
+    warn: false,
+    files: [],
+  };
+  let i = 0;
+  let endOfFlags = false;
+
+  while (i < argv.length) {
+    const a = argv[i];
+    if (endOfFlags || a === "-" || !a.startsWith("-")) {
+      opts.files.push(a);
+      i++;
+      continue;
+    }
+    if (a === "--") {
+      endOfFlags = true;
+      i++;
+      continue;
+    }
+    if (a === "--help") return { options: opts, help: true };
+    if (a === "--binary" || a === "-b") opts.binary = true;
+    else if (a === "--text" || a === "-t") opts.binary = false;
+    else if (a === "--check" || a === "-c") opts.check = true;
+    else if (a === "--quiet") opts.quiet = true;
+    else if (a === "--status") opts.status = true;
+    else if (a === "--strict") opts.strict = true;
+    else if (a === "--warn" || a === "-w") opts.warn = true;
+    else if (a.startsWith("-") && a.length > 1 && !a.startsWith("--")) {
+      // Allow grouped short flags like -bc
+      for (const ch of a.slice(1)) {
+        if (ch === "b") opts.binary = true;
+        else if (ch === "t") opts.binary = false;
+        else if (ch === "c") opts.check = true;
+        else if (ch === "w") opts.warn = true;
+        else return { options: opts, help: false, error: `unknown option: -${ch}` };
+      }
+    } else {
+      return { options: opts, help: false, error: `unknown option: ${a}` };
+    }
+    i++;
+  }
+  return { options: opts, help: false };
+}
+
+export function helpText(): string {
+  return HELP;
+}
+
+export async function hashStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const md = new Md5();
+  for await (const chunk of stream) {
+    md.update(chunk as Buffer);
+  }
+  return md.hex();
+}
+
+export async function hashFile(path: string): Promise<string> {
+  if (path === "-") return hashStream(process.stdin);
+  // Use a stream so large files don't need to fit in memory.
+  const stream = createReadStream(path);
+  return hashStream(stream);
+}
+
+export function formatLine(hash: string, file: string, binary: boolean): string {
+  return `${hash} ${binary ? "*" : " "}${file}`;
+}
+
+export interface ChecksumLine {
+  hash: string;
+  binary: boolean;
+  file: string;
+}
+
+// Parse one line from a checksums file. Returns null if it isn't a valid line.
+export function parseChecksumLine(line: string): ChecksumLine | null {
+  // Strip a single trailing \r so CRLF files still parse.
+  const l = line.endsWith("\r") ? line.slice(0, -1) : line;
+  // Format: <32 hex chars><space><space-or-asterisk><filename>
+  if (l.length < 34) return null;
+  const hash = l.slice(0, 32);
+  if (!/^[0-9a-fA-F]{32}$/.test(hash)) return null;
+  if (l[32] !== " ") return null;
+  const marker = l[33];
+  if (marker !== " " && marker !== "*") return null;
+  const file = l.slice(34);
+  if (file.length === 0) return null;
+  return { hash: hash.toLowerCase(), binary: marker === "*", file };
+}
+
+export interface CheckSummary {
+  total: number;
+  failed: number;
+  missing: number;
+  malformed: number;
+}
+
+export interface CheckOutput {
+  lines: string[];
+  warnings: string[];
+  summary: CheckSummary;
+}
+
+export async function runCheck(
+  checkFile: string,
+  opts: Pick<Options, "quiet" | "status" | "warn">,
+  read: (p: string) => Promise<string> = readTextFile,
+  hash: (p: string) => Promise<string> = hashFile,
+): Promise<CheckOutput> {
+  const text = await read(checkFile);
+  const out: CheckOutput = {
+    lines: [],
+    warnings: [],
+    summary: { total: 0, failed: 0, missing: 0, malformed: 0 },
+  };
+  const rawLines = text.split("\n");
+  // Drop a trailing empty produced by a final newline.
+  if (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") rawLines.pop();
+
+  let lineNo = 0;
+  for (const raw of rawLines) {
+    lineNo++;
+    if (raw === "") continue;
+    const parsed = parseChecksumLine(raw);
+    if (!parsed) {
+      out.summary.malformed++;
+      if (opts.warn) {
+        out.warnings.push(
+          `md5sum: ${checkFile}: ${lineNo}: improperly formatted MD5 checksum line`,
+        );
+      }
+      continue;
+    }
+    out.summary.total++;
+    let actual: string;
+    try {
+      actual = await hash(parsed.file);
+    } catch {
+      out.summary.missing++;
+      out.summary.failed++;
+      if (!opts.status) {
+        out.lines.push(`${parsed.file}: FAILED open or read`);
+      }
+      if (!opts.status) {
+        out.warnings.push(`md5sum: ${parsed.file}: No such file or directory`);
+      }
+      continue;
+    }
+    if (actual === parsed.hash) {
+      if (!opts.quiet && !opts.status) {
+        out.lines.push(`${parsed.file}: OK`);
+      }
+    } else {
+      out.summary.failed++;
+      if (!opts.status) {
+        out.lines.push(`${parsed.file}: FAILED`);
+      }
+    }
+  }
+
+  if (out.summary.total === 0 && out.summary.malformed > 0 && !opts.status) {
+    out.warnings.push(
+      `md5sum: ${checkFile}: no properly formatted MD5 checksum lines found`,
+    );
+  }
+  if (out.summary.malformed > 0 && out.summary.total > 0 && !opts.status) {
+    out.warnings.push(
+      `md5sum: WARNING: ${out.summary.malformed} line${out.summary.malformed === 1 ? "" : "s"} is improperly formatted`,
+    );
+  }
+  if (out.summary.missing > 0 && !opts.status) {
+    out.warnings.push(
+      `md5sum: WARNING: ${out.summary.missing} listed file${out.summary.missing === 1 ? "" : "s"} could not be read`,
+    );
+  }
+  const mismatched = out.summary.failed - out.summary.missing;
+  if (mismatched > 0 && !opts.status) {
+    out.warnings.push(
+      `md5sum: WARNING: ${mismatched} computed checksum${mismatched === 1 ? "" : "s"} did NOT match`,
+    );
+  }
+
+  return out;
+}
+
+async function readTextFile(path: string): Promise<string> {
+  const fh = await open(path, "r");
+  try {
+    const buf = await fh.readFile();
+    return buf.toString("utf8");
+  } finally {
+    await fh.close();
+  }
+}
+
+export interface RunResult {
+  stdout: string[];
+  stderr: string[];
+  exitCode: number;
+}
+
+export async function run(argv: readonly string[]): Promise<RunResult> {
+  const parsed = parseArgs(argv);
+  const result: RunResult = { stdout: [], stderr: [], exitCode: 0 };
+
+  if (parsed.help) {
+    result.stdout.push(helpText());
+    return result;
+  }
+  if (parsed.error) {
+    result.stderr.push(`md5sum: ${parsed.error}`);
+    result.stderr.push(`Try 'md5sum --help' for more information.`);
+    result.exitCode = 1;
+    return result;
+  }
+
+  const { options } = parsed;
+  const files = options.files.length === 0 ? ["-"] : options.files;
+
+  if (options.check) {
+    let any = false;
+    for (const cf of files) {
+      try {
+        const co = await runCheck(cf, options);
+        any = any || co.summary.total > 0;
+        for (const l of co.lines) result.stdout.push(l);
+        for (const w of co.warnings) result.stderr.push(w);
+        if (co.summary.failed > 0) result.exitCode = 1;
+        if (options.strict && co.summary.malformed > 0) result.exitCode = 1;
+        if (co.summary.total === 0 && co.summary.malformed > 0) result.exitCode = 1;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        result.stderr.push(`md5sum: ${cf}: ${msg}`);
+        result.exitCode = 1;
+      }
+    }
+    return result;
+  }
+
+  for (const f of files) {
+    try {
+      const h = await hashFile(f);
+      const name = f === "-" ? "-" : f;
+      result.stdout.push(formatLine(h, name, options.binary));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      result.stderr.push(`md5sum: ${f}: ${msg}`);
+      result.exitCode = 1;
+    }
+  }
+  return result;
+}

--- a/md5sum-typescript/test/md5.test.ts
+++ b/md5sum-typescript/test/md5.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { md5Hex, Md5 } from "../src/md5";
+
+// RFC 1321 test vectors plus a few extras.
+const vectors: Array<[string, string]> = [
+  ["", "d41d8cd98f00b204e9800998ecf8427e"],
+  ["a", "0cc175b9c0f1b6a831c399e269772661"],
+  ["abc", "900150983cd24fb0d6963f7d28e17f72"],
+  ["message digest", "f96b697d7cb7938d525a2f31aaf161d0"],
+  ["abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b"],
+  [
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    "d174ab98d277d9f5a5611c2c9f419d9f",
+  ],
+  [
+    "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+    "57edf4a22be3c955ac49da2e2107b67a",
+  ],
+];
+
+describe("md5", () => {
+  for (const [input, expected] of vectors) {
+    it(`hashes ${JSON.stringify(input.length > 20 ? input.slice(0, 20) + "..." : input)}`, () => {
+      assert.equal(md5Hex(input), expected);
+    });
+  }
+
+  it("matches when fed in many small chunks (streaming)", () => {
+    const input = "The quick brown fox jumps over the lazy dog";
+    const expected = "9e107d9d372bb6826bd81d3542a419d6";
+    const md = new Md5();
+    for (const c of input) md.update(c);
+    assert.equal(md.hex(), expected);
+    assert.equal(md5Hex(input), expected);
+  });
+
+  it("handles message exactly 55 bytes (padding edge: no extra block)", () => {
+    const s = "a".repeat(55);
+    // Cross-checked against system md5sum:
+    //   $ printf '%.0sa' {1..55} | md5sum
+    assert.equal(md5Hex(s), "ef1772b6dff9a122358552954ad0df65");
+  });
+
+  it("handles message exactly 56 bytes (padding edge: extra block needed)", () => {
+    const s = "a".repeat(56);
+    assert.equal(md5Hex(s), "3b0c8ac703f828b04c6c197006d17218");
+  });
+
+  it("handles message exactly 64 bytes (full block)", () => {
+    const s = "a".repeat(64);
+    assert.equal(md5Hex(s), "014842d480b571495a4a0363793f7367");
+  });
+
+  it("handles a large message (1MB of 'a')", () => {
+    const s = "a".repeat(1024 * 1024);
+    assert.equal(md5Hex(s), "7202826a7791073fe2787f0c94603278");
+  });
+
+  it("hashes binary data with null bytes", () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0x00]);
+    assert.equal(md5Hex(buf), "744190d34d085916ee22990db1243b42");
+  });
+});

--- a/md5sum-typescript/test/md5sum.test.ts
+++ b/md5sum-typescript/test/md5sum.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseArgs,
+  parseChecksumLine,
+  formatLine,
+  runCheck,
+  run,
+} from "../src/md5sum";
+import { md5Hex } from "../src/md5";
+
+describe("parseArgs", () => {
+  it("collects files when no flags are given", () => {
+    const r = parseArgs(["a.txt", "b.txt"]);
+    assert.equal(r.help, false);
+    assert.equal(r.error, undefined);
+    assert.deepEqual(r.options.files, ["a.txt", "b.txt"]);
+  });
+
+  it("recognizes -b, -c, -t and long forms", () => {
+    const r = parseArgs(["-b", "--check", "file.sum"]);
+    assert.equal(r.options.binary, true);
+    assert.equal(r.options.check, true);
+    assert.deepEqual(r.options.files, ["file.sum"]);
+  });
+
+  it("treats - as a filename, not a flag", () => {
+    const r = parseArgs(["-"]);
+    assert.deepEqual(r.options.files, ["-"]);
+  });
+
+  it("supports -- to stop flag parsing", () => {
+    const r = parseArgs(["--", "-b"]);
+    assert.deepEqual(r.options.files, ["-b"]);
+  });
+
+  it("expands grouped short flags", () => {
+    const r = parseArgs(["-bc", "sums.md5"]);
+    assert.equal(r.options.binary, true);
+    assert.equal(r.options.check, true);
+    assert.deepEqual(r.options.files, ["sums.md5"]);
+  });
+
+  it("reports an error for unknown options", () => {
+    const r = parseArgs(["--bogus"]);
+    assert.ok(r.error);
+  });
+});
+
+describe("formatLine", () => {
+  it("uses two spaces in text mode", () => {
+    assert.equal(formatLine("d41d8cd98f00b204e9800998ecf8427e", "foo", false),
+      "d41d8cd98f00b204e9800998ecf8427e  foo");
+  });
+  it("uses space-asterisk in binary mode", () => {
+    assert.equal(formatLine("d41d8cd98f00b204e9800998ecf8427e", "foo", true),
+      "d41d8cd98f00b204e9800998ecf8427e *foo");
+  });
+});
+
+describe("parseChecksumLine", () => {
+  it("parses a text-mode line", () => {
+    const r = parseChecksumLine("d41d8cd98f00b204e9800998ecf8427e  empty.txt");
+    assert.deepEqual(r, { hash: "d41d8cd98f00b204e9800998ecf8427e", binary: false, file: "empty.txt" });
+  });
+  it("parses a binary-mode line", () => {
+    const r = parseChecksumLine("d41d8cd98f00b204e9800998ecf8427e *empty.bin");
+    assert.deepEqual(r, { hash: "d41d8cd98f00b204e9800998ecf8427e", binary: true, file: "empty.bin" });
+  });
+  it("tolerates a trailing CR", () => {
+    const r = parseChecksumLine("d41d8cd98f00b204e9800998ecf8427e  empty.txt\r");
+    assert.equal(r?.file, "empty.txt");
+  });
+  it("rejects malformed lines", () => {
+    assert.equal(parseChecksumLine("nope"), null);
+    assert.equal(parseChecksumLine("d41d8cd98f00b204e9800998ecf8427e empty.txt"), null);
+    assert.equal(parseChecksumLine(""), null);
+  });
+  it("rejects non-hex digests", () => {
+    assert.equal(parseChecksumLine("zzz1d8cd98f00b204e9800998ecf8427e  empty.txt"), null);
+  });
+});
+
+describe("end-to-end against the filesystem", () => {
+  let dir: string;
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "md5sum-test-"));
+    await writeFile(join(dir, "empty.txt"), "");
+    await writeFile(join(dir, "abc.txt"), "abc");
+    await writeFile(join(dir, "bin.dat"), Buffer.from([0, 1, 2, 0xff]));
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("hashes files matching the standard format", async () => {
+    const r = await run([join(dir, "empty.txt"), join(dir, "abc.txt")]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout.length, 2);
+    assert.match(r.stdout[0], /^d41d8cd98f00b204e9800998ecf8427e  /);
+    assert.match(r.stdout[1], /^900150983cd24fb0d6963f7d28e17f72  /);
+  });
+
+  it("emits an asterisk for binary mode", async () => {
+    const r = await run(["-b", join(dir, "bin.dat")]);
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout[0], / \*/);
+  });
+
+  it("reports an error and non-zero exit for a missing file", async () => {
+    const r = await run([join(dir, "nope.txt")]);
+    assert.notEqual(r.exitCode, 0);
+    assert.ok(r.stderr.join("\n").includes("nope.txt"));
+  });
+
+  it("verifies a checksum file with -c", async () => {
+    const sums =
+      `${md5Hex("")}  ${join(dir, "empty.txt")}\n` +
+      `${md5Hex("abc")}  ${join(dir, "abc.txt")}\n`;
+    const sumsPath = join(dir, "good.md5");
+    await writeFile(sumsPath, sums);
+    const r = await run(["-c", sumsPath]);
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.some((l) => l.endsWith(": OK")));
+    assert.equal(r.stdout.filter((l) => l.endsWith(": OK")).length, 2);
+  });
+
+  it("reports FAILED for a mismatched hash", async () => {
+    const sums = `00000000000000000000000000000000  ${join(dir, "abc.txt")}\n`;
+    const sumsPath = join(dir, "bad.md5");
+    await writeFile(sumsPath, sums);
+    const r = await run(["-c", sumsPath]);
+    assert.notEqual(r.exitCode, 0);
+    assert.ok(r.stdout.some((l) => l.endsWith(": FAILED")));
+  });
+
+  it("suppresses OK output with --quiet but still reports FAILED", async () => {
+    const sums =
+      `${md5Hex("")}  ${join(dir, "empty.txt")}\n` +
+      `00000000000000000000000000000000  ${join(dir, "abc.txt")}\n`;
+    const sumsPath = join(dir, "mix.md5");
+    await writeFile(sumsPath, sums);
+    const r = await run(["-c", "--quiet", sumsPath]);
+    assert.notEqual(r.exitCode, 0);
+    assert.ok(!r.stdout.some((l) => l.endsWith(": OK")));
+    assert.ok(r.stdout.some((l) => l.endsWith(": FAILED")));
+  });
+
+  it("suppresses all output with --status", async () => {
+    const sums = `${md5Hex("")}  ${join(dir, "empty.txt")}\n`;
+    const sumsPath = join(dir, "status.md5");
+    await writeFile(sumsPath, sums);
+    const r = await run(["-c", "--status", sumsPath]);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout.length, 0);
+  });
+
+  it("propagates malformed-line errors when no good lines exist", async () => {
+    const sumsPath = join(dir, "junk.md5");
+    await writeFile(sumsPath, "not a checksum at all\n");
+    const r = await run(["-c", sumsPath]);
+    assert.notEqual(r.exitCode, 0);
+    assert.ok(
+      r.stderr.join("\n").includes("no properly formatted MD5 checksum lines found"),
+    );
+  });
+
+  it("runCheck reports missing files as FAILED open or read", async () => {
+    const sumsPath = join(dir, "missing.md5");
+    const fakeFile = join(dir, "ghost.txt");
+    await writeFile(sumsPath, `${md5Hex("anything")}  ${fakeFile}\n`);
+    const out = await runCheck(sumsPath, { quiet: false, status: false, warn: false });
+    assert.equal(out.summary.missing, 1);
+    assert.ok(out.lines.some((l) => l.endsWith(": FAILED open or read")));
+  });
+});

--- a/md5sum-typescript/tsconfig.json
+++ b/md5sum-typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "lib": ["es2022"],
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "test"]
+}


### PR DESCRIPTION
Implements MD5 from RFC 1321 (no node:crypto) plus a CLI matching GNU
md5sum's output format, binary mode (*filename), and -c check mode with
--quiet/--status/--strict/--warn. Verified against coreutils 9.4 on
text/binary files, /bin/ls, stdin, and bidirectional check round-trips.
35 tests cover RFC vectors, padding boundaries, argv parsing, and
end-to-end behavior.